### PR TITLE
use stripes v6 compatible libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Make the code lint-clean. Fixes #25.
 * Update package file to use modern Stripes-module description. Fixes #27.
 * Create and implement an icon for this app. Fixes #26.
+* Updated `stripes` to v6; removed unused incompatible deps (redux, react-redux). Fixes #29.
 
 ## 1.0.0 (https://github.com/folio-org/ui-app-template/tree/v1.0.0) (2020-03-02)
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "@babel/polyfill": "^7.12.1",
     "@folio/eslint-config-stripes": "^5.2.0",
     "@folio/stripes": "^5.0.0",
-    "@folio/stripes-cli": "^1.18.0",
-    "@folio/stripes-components": "^8.0.0",
-    "@folio/stripes-core": "^6.0.0",
+    "@folio/stripes-cli": "^2.2.0",
+    "@folio/stripes-components": "^9.0.0",
+    "@folio/stripes-core": "^7.0.0",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.3",
     "@testing-library/user-event": "^12.6.2",
@@ -44,9 +44,7 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-intl": "^5.8.0",
-    "react-redux": "^5.1.2",
     "react-router-dom": "^5.2.0",
-    "redux": "^4.0.0",
     "regenerator-runtime": "^0.13.3",
     "sinon": "^7.3.2"
   },
@@ -64,7 +62,7 @@
     "uuid": "^8.3.1"
   },
   "peerDependencies": {
-    "@folio/stripes": "^5.0.0",
+    "@folio/stripes": "^6.0.0",
     "core-js": "^3.6.1",
     "react": "*",
     "react-intl": "^5.8.0",


### PR DESCRIPTION
Update dev-deps for compatibility with `@folio/stripes` `^6.0.0` and
remove unused/incompatible deps.

Refs #29